### PR TITLE
Adding Types Declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,61 @@
+declare module "nav2d" {
+    export class Vector {
+        constructor(x: number, y: number);
+
+        add(other: Vector): Vector;
+        sub(other: Vector): Vector;
+        mul(other: Vector): Vector;
+        div(other: Vector): Vector;
+        length(): number;
+        equals(other: Vector): boolean;
+        angle(other: Vector): number;
+        counterclockwiseAngle(other: Vector): number;
+        toString(): string;
+    }
+
+    export function dot(a: Vector, b: Vector): number;
+    export function cross(a: Vector, b: Vector): number;
+    export function isclose(a: number, b: number, eps?: number): boolean;
+    export function clip(a: number, b: number, v: number): number;
+
+    export class Edge {
+        constructor(p1: Point, p2: Point);
+
+        p1: Vector;
+        p2: Vector;
+
+        length(): number;
+        direction(): Vector;
+        onEdge(point: Point): boolean;
+        parallel(other: Edge): boolean;
+        collinear(other: Edge): boolean;
+        overlap(other: Edge): boolean | null;
+        equals(other: Edge): boolean;
+    }
+
+    export class Polygon {
+        constructor(points: Point[])
+
+        points: Vector[];
+        bounds: [number, number, number, number];
+
+        edges(): Edge[];
+        centroid(): Vector;
+        centroidDistance(other: Polygon): number;
+        contains(point: Point): boolean;
+        onEdge(point: Point): Edge | null;
+        touches(otherEdge: Edge): Edge | null;
+        boundsSize(): [number, number, number, number];
+    }
+
+    export class NavMesh {
+        constructor(polygons: Polygon[] | Point[][], costFunc?: (polygon1: any, polygon2: any, portal: any) => {}, heuristicFunc?: (poly: any, to: any) => {});
+
+        polygons: Polygon[];
+        pointQuerySize: number;
+
+        findPath(from: Point, to: Point): Point[] | null
+    }
+
+    export type Point = Vector | [number, number] | { x: number, y: number }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ declare module "nav2d" {
     }
 
     export class NavMesh {
-        constructor(polygons: Polygon[] | Point[][], costFunc?: (polygon1: any, polygon2: any, portal: any) => {}, heuristicFunc?: (poly: any, to: any) => {});
+        constructor(polygons: Point[][], costFunc?: (polygon1: any, polygon2: any, portal: any) => {}, heuristicFunc?: (poly: any, to: any) => {});
 
         polygons: Polygon[];
         pointQuerySize: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,10 @@ declare module "nav2d" {
     export class Vector {
         constructor(x: number, y: number);
 
-        add(other: Vector): Vector;
-        sub(other: Vector): Vector;
-        mul(other: Vector): Vector;
-        div(other: Vector): Vector;
+        add(other: Vector | number): Vector;
+        sub(other: Vector | number): Vector;
+        mul(other: Vector | number): Vector;
+        div(other: Vector | number): Vector;
         length(): number;
         equals(other: Vector): boolean;
         angle(other: Vector): number;
@@ -34,7 +34,7 @@ declare module "nav2d" {
     }
 
     export class Polygon {
-        constructor(points: Point[])
+        constructor(points: Point[]);
 
         points: Vector[];
         bounds: [number, number, number, number];
@@ -49,13 +49,15 @@ declare module "nav2d" {
     }
 
     export class NavMesh {
-        constructor(polygons: Point[][], costFunc?: (polygon1: any, polygon2: any, portal: any) => {}, heuristicFunc?: (poly: any, to: any) => {});
+        constructor(polygons: Point[][], costFunc?: CostFunction, heuristicFunc?: HeuristicFunction);
 
         polygons: Polygon[];
         pointQuerySize: number;
 
-        findPath(from: Point, to: Point): Point[] | null
+        findPath(from: Point, to: Point): Point[] | null;
     }
 
-    export type Point = Vector | [number, number] | { x: number, y: number }
+    export type Point = Vector | [number, number] | { x: number, y: number };
+    export type CostFunction = (polygon1: Polygon, polygon2: Polygon, portal: Edge) => number;
+    export type HeuristicFunction = (poly: Polygon, to: Polygon) => number;
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "main": "dist/nav2d.min.js",
     "unpkg": "dist/nav2d.min.js",
     "module": "src/nav2d.js",
+    "types": "index.d.ts",
     "keywords": [
         "navigation mesh",
         "nav",


### PR DESCRIPTION
fixes #28

Howdy, and Happy Thanksgiving! Hope you are well. Thank you for your work. I wanted to use this lib in a ts project and ended up writing the types for myself and saw you say in #28 that you'd take a PR for it, so here it is.

I nearly went the jsdoc route since that is very _en vogue_ in 2023, in order to let typescript generate the type declarations automatically. However, that would have required touching more files. Since this is a very static lib, I instead went the minimalist route, only what is necessary to provide types. It pretty much matches the api doc section of the readme.

The only "creative license" I took was instead of having `Point` be strictly an alias for `Vector`, I declared `Point` to optionally be `Vector | [number, number] | { x: number, y: number }` to reflect the flexibility that you provide with your auto normalization via `_normalizePoint(point)`. I then used this flexible point definition for all type 'inputs' from constructors and functions but used `Vector`'s for all return values since there is no ambiguity there. It's not technically exactly the same as the underlying js since `Point` and `Vector` are identical in the js, but it's functionally pretty identical while maintaining the input type flexibility in a sane typescript way. Tested this in a personal TS project and it seems to work well.